### PR TITLE
1658142: Add mon-data location in case of CEPH_DATA_DIR override

### DIFF
--- a/devstack/lib/ceph
+++ b/devstack/lib/ceph
@@ -387,7 +387,8 @@ EOF
 
     # bootstrap the ceph monitor
     sudo ceph-mon -c ${CEPH_CONF_FILE} --mkfs -i $(hostname) \
-         --keyring ${CEPH_DATA_DIR}/tmp/keyring.mon.$(hostname)
+         --keyring ${CEPH_DATA_DIR}/tmp/keyring.mon.$(hostname) \
+         --mon-data ${CEPH_DATA_DIR}/mon/ceph-$(hostname)
 
     if [[ $RUN_AS == 'ceph' ]] ; then
         sudo chown -R ceph. ${CEPH_DATA_DIR}


### PR DESCRIPTION
Resolves https://bugs.launchpad.net/devstack-plugin-ceph/+bug/1658142.